### PR TITLE
Chore: Add wp-env for local dev

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -2,6 +2,7 @@
 .editorconfig
 .gitignore
 .github
+.wp-env.json
 CHANGELOG.md
 jest.config.js
 jest.setup.js
@@ -11,3 +12,4 @@ webpack.config.js
 assets
 src
 tests
+bin

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,17 @@
+{
+	"plugins": [
+		"."
+	],
+	"phpVersion": "8.2",
+	"port": 5437,
+	"testsPort": 5438,
+	"config": {
+		"WP_DEBUG": true,
+		"WP_DEBUG_LOG": true,
+		"WP_SITEURL": "http://tpbe.localhost",
+		"WP_HOME": "http://tpbe.localhost"
+	},
+	"lifecycleScripts": {
+		"afterStart": "./bin/setup.sh"
+	}
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.4
+* Add wp-env for local development.
+
 ## 1.0.3
 * Update README docs.
 * Tested up to WP 6.7.2.

--- a/README.md
+++ b/README.md
@@ -15,11 +15,32 @@ This plugin provides a quick way to __delete__ or __trash__ a Post from __within
 
 https://github.com/user-attachments/assets/f02442d8-ff46-49d3-9bb7-9907b8d7174b
 
-## Development
+---
 
-### Setup
+## Contribute
 
-- Clone the repository.
-- Make sure you have [Node](https://nodejs.org) installed on your computer.
-- Run `yarn install && yarn build` to build JS dependencies.
-- For local development, you can use [Docker](https://docs.docker.com/install/) or [Local by Flywheel](https://localwp.com/).
+Contributions are __welcome__ and will be fully __credited__. To contribute, please fork this repo and raise a PR (Pull Request) against the `master` branch.
+
+### Pre-requisites
+
+You should have the following tools before proceeding to the next steps:
+
+- Composer
+- Yarn
+- Docker
+
+To enable you start development, please run:
+
+```bash
+yarn start
+```
+
+This should spin up a local WP env instance for you to work with at:
+
+```bash
+http://tpbe.localhost:5437
+```
+
+You should now have a functioning local WP env to work with. To login to the `wp-admin` backend, please username as `admin` & password as `password`.
+
+__Awesome!__ - Thanks for being interested in contributing your time and code to this project!

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+wp-env run cli wp theme activate twentytwentythree
+wp-env run cli wp rewrite structure /%postname%
+wp-env run cli wp option update blogname "Trash Post in Block Editor"
+wp-env run cli wp option update blogdescription "Delete a Post from within the WP Block Editor."

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "boot": "yarn install",
     "test": "npm-run-all --parallel test:*",
     "test:js": "jest --passWithNoTests",
-    "ci": "yarn test:js && yarn lint:js && yarn lint:php",
+    "ci": "yarn test:js && yarn lint:js",
     "wp-env": "wp-env",
     "bash": "wp-env run cli bash"
   },

--- a/package.json
+++ b/package.json
@@ -6,11 +6,16 @@
   "license": "GPL-2.0-or-later",
   "homepage": "https://github.com/badasswp/convert-blocks-to-json#readme",
   "scripts": {
-    "start": "npm install && composer install",
-    "dev": "webpack --watch",
+    "start": "yarn boot && yarn build && yarn wp-env start",
+    "stop": "yarn wp-env stop",
+    "watch": "webpack --watch",
     "build": "webpack",
+    "boot": "yarn install",
     "test": "npm-run-all --parallel test:*",
-    "test:js": "jest --passWithNoTests"
+    "test:js": "jest --passWithNoTests",
+    "ci": "yarn test:js && yarn lint:js && yarn lint:php",
+    "wp-env": "wp-env",
+    "bash": "wp-env run cli bash"
   },
   "devDependencies": {
     "@babel/core": "^7.22.11",
@@ -21,6 +26,7 @@
     "@testing-library/jest-dom": "5.17",
     "@testing-library/react": "15.0.6",
     "@types/jest": "^29.5.4",
+    "@wordpress/env": "^10.23.0",
     "@wordpress/eslint-plugin": "^15.0.0",
     "@wordpress/scripts": "^26.9.0",
     "css-loader": "^6.8.1",


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/trash-post-in-block-editor/issues/2).

## Description / Background Context

At the moment, contributors have to use their own methods of setting up this repo. We need to provide a consistent way for users to spin up this project's repo and contribute quickly perhaps using WP's `wp-env` so that users can now spin up their local instance by running:

```bash
yarn wp-env start
```

This PR implements this correctly.

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `rm -rf node_modules && yarn start`.
3. The repo should now build and boot up the `wp-env` instance ready for the user.
4. User should be able to access the site at: `http://tpbe.localhost:5437`