### PR TITLE
Enforce WP linting across plugin

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -1,5 +1,7 @@
 .babelrc
 .editorconfig
+.eslintignore
+.eslintrc.js
 .gitignore
 .github
 .wp-env.json

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,4 +10,4 @@ trim_trailing_whitespace = true
 
 [*.{js,jsx,ts,tsx,json,yml,yaml,babelrc,md}]
 indent_size = 2
-indent_style = space
+indent_style = tab

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+node_modules/
+vendor/
+build/
+dist/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+	root: true,
+	extends: [ 'plugin:@wordpress/recommended' ],
+	rules: {
+		'import/no-extraneous-dependencies': 'off',
+	},
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,18 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Node.js 18.x
+    - name: Set up Node.js 20.x
       uses: actions/setup-node@v3
       with:
-        node-version: 18.x
+        node-version: 20.x
 
     - name: Install NPM
       run: |
         yarn install
+
+    - name: Check JS Linting
+      run: |
+        yarn lint:js
 
     - name: Run Test Suites
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.4
+* Enforce WP linting across plugin codebase.
+
 ## 1.0.3
 * Update README docs.
 * Tested up to WP 6.7.2.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,17 +1,15 @@
-const baseConfig = require('@wordpress/scripts/config/jest-unit.config.js');
+const baseConfig = require( '@wordpress/scripts/config/jest-unit.config.js' );
 
 module.exports = {
-  ...baseConfig,
-  preset: 'ts-jest',
-  testEnvironment: 'jsdom',
-  setupFilesAfterEnv: [
-    './jest.setup.js'
-  ],
-  transform: {
-    '^.+\\.jsx?$': 'babel-jest',
-  },
-  moduleNameMapper: {
-    'uuid': require.resolve('uuid'),
-    '\\.(css|scss)$': 'identity-obj-proxy',
-  },
+	...baseConfig,
+	preset: 'ts-jest',
+	testEnvironment: 'jsdom',
+	setupFilesAfterEnv: [ './jest.setup.js' ],
+	transform: {
+		'^.+\\.jsx?$': 'babel-jest',
+	},
+	moduleNameMapper: {
+		uuid: require.resolve( 'uuid' ),
+		'\\.(css|scss)$': 'identity-obj-proxy',
+	},
 };

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "boot": "yarn install",
     "test": "npm-run-all --parallel test:*",
     "test:js": "jest --passWithNoTests",
+    "lint:js": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "lint:js:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "ci": "yarn test:js && yarn lint:js && yarn lint:php",
     "wp-env": "wp-env",
     "bash": "wp-env run cli bash"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@testing-library/react": "15.0.6",
     "@types/jest": "^29.5.4",
     "@wordpress/env": "^10.23.0",
-    "@wordpress/eslint-plugin": "^15.0.0",
+    "@wordpress/eslint-plugin": "^22.9.0",
     "@wordpress/scripts": "^26.9.0",
     "css-loader": "^6.8.1",
     "file-loader": "^6.2.0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,62 +16,63 @@ import './styles/app.scss';
  *
  * @since 1.0.0
  *
- * @returns {JSX.Element}
+ * @return {JSX.Element} TrashPostInBlockEditor
  */
 const TrashPostInBlockEditor = (): JSX.Element => {
-  const [ isModalVisible, setIsModalVisible ] = useState( false );
+	const [ isModalVisible, setIsModalVisible ] = useState( false );
 
-  return (
-    <Fragment>
-      <PluginSidebar
-        name="tpbe-sidebar"
-        title={ __( 'Trash Post in Block Editor', 'trash-post-in-block-editor' ) }
-        icon="trash"
-      >
-        <PanelBody>
-          <div id="tpbe">
-            <Button
-              variant="primary"
-              onClick={ () => setIsModalVisible( true ) }
-            >
-              { __( 'Trash Post', 'trash-post-in-block-editor' ) }
-            </Button>
-          </div>
-        </PanelBody>
-      </PluginSidebar>
-      {
-        isModalVisible && (
-          <Modal
-            title={ __( 'Trash Post', 'trash-post-in-block-editor' ) }
-            onRequestClose={ () => setIsModalVisible( false ) }
-            className="trash-post-modal"
-          >
-            <p style={{ textAlign: 'center' }}>
-              { __( 'Are you sure you want to delete this Post?', 'trash-post-in-block-editor' ) }
-              </p>
-            <div id="trash-post-modal__button-group">
-              <Button
-                variant="primary"
-                onClick={trashPost}
-              >
-                { __( 'Yes', 'trash-post-in-block-editor' ) }
-              </Button>
-              <Button
-                variant="secondary"
-                onClick={ () => setIsModalVisible( false ) }
-              >
-                { __( 'No', 'trash-post-in-block-editor' ) }
-              </Button>
-            </div>
-          </Modal>
-        )
-      }
-    </Fragment>
-  );
+	return (
+		<Fragment>
+			<PluginSidebar
+				name="tpbe-sidebar"
+				title={ __(
+					'Trash Post in Block Editor',
+					'trash-post-in-block-editor'
+				) }
+				icon="trash"
+			>
+				<PanelBody>
+					<div id="tpbe">
+						<Button
+							variant="primary"
+							onClick={ () => setIsModalVisible( true ) }
+						>
+							{ __( 'Trash Post', 'trash-post-in-block-editor' ) }
+						</Button>
+					</div>
+				</PanelBody>
+			</PluginSidebar>
+			{ isModalVisible && (
+				<Modal
+					title={ __( 'Trash Post', 'trash-post-in-block-editor' ) }
+					onRequestClose={ () => setIsModalVisible( false ) }
+					className="trash-post-modal"
+				>
+					<p style={ { textAlign: 'center' } }>
+						{ __(
+							'Are you sure you want to delete this Post?',
+							'trash-post-in-block-editor'
+						) }
+					</p>
+					<div id="trash-post-modal__button-group">
+						<Button variant="primary" onClick={ trashPost }>
+							{ __( 'Yes', 'trash-post-in-block-editor' ) }
+						</Button>
+						<Button
+							variant="secondary"
+							onClick={ () => setIsModalVisible( false ) }
+						>
+							{ __( 'No', 'trash-post-in-block-editor' ) }
+						</Button>
+					</div>
+				</Modal>
+			) }
+		</Fragment>
+	);
 };
 
 registerPlugin( 'trash-post-in-block-editor', {
-  render: TrashPostInBlockEditor,
+	render: TrashPostInBlockEditor,
 } );
 
 export default TrashPostInBlockEditor;

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -9,25 +9,23 @@ import { select, dispatch } from '@wordpress/data';
  *
  * @since 1.0.0
  *
- * @returns {void}
+ * @return {void}
  */
 export const trashPost = async () => {
-  const { getCurrentPostId } = select( 'core/editor' );
-  const { createWarningNotice } = dispatch( 'core/notices' ) as any;
+	const { getCurrentPostId } = select( 'core/editor' );
+	const { createWarningNotice } = dispatch( 'core/notices' ) as any;
 
-  try {
-    await apiFetch(
-      {
-        path: '/tpbe/v1/trash',
-        method: 'POST',
-        data: {
-          id: getCurrentPostId()
-        },
-      }
-    );
+	try {
+		await apiFetch( {
+			path: '/tpbe/v1/trash',
+			method: 'POST',
+			data: {
+				id: getCurrentPostId(),
+			},
+		} );
 
-    window.location.href = `${tpbe.url}`
-  } catch (e) {
-    createWarningNotice(e);
-  }
-}
+		window.location.href = `${ tpbe.url }`;
+	} catch ( e ) {
+		createWarningNotice( e );
+	}
+};

--- a/tests/Trash.test.tsx
+++ b/tests/Trash.test.tsx
@@ -6,63 +6,78 @@ import TrashPostInBlockEditor from '../src/index';
 import { trashPost } from '../src/utils';
 
 jest.mock( '../src/utils', () => ( {
-  trashPost: jest.fn(),
+	trashPost: jest.fn(),
 } ) );
 
 jest.mock( '@wordpress/editor', () => ( {
-  PluginSidebar: jest.fn( ( { title, children } ) => {
-    return (
-      <div className="editor-sidebar">
-        <h2 className="interface-complementary-area-header__title">{title}</h2>
-        {children}
-      </div>
-    )
-  } ),
+	PluginSidebar: jest.fn( ( { title, children } ) => {
+		return (
+			<div className="editor-sidebar">
+				<h2 className="interface-complementary-area-header__title">
+					{ title }
+				</h2>
+				{ children }
+			</div>
+		);
+	} ),
 } ) );
 
 describe( 'TrashPostInBlockEditor', () => {
-  it( 'renders sidebar and Trash Post button', () => {
-    const { container } = render( <TrashPostInBlockEditor /> );
+	it( 'renders sidebar and Trash Post button', () => {
+		const { container } = render( <TrashPostInBlockEditor /> );
 
-    // Test if Sidebar title is displayed.
-    expect( screen.getByText( 'Trash Post in Block Editor' ) ).toBeInTheDocument();
+		// Test if Sidebar title is displayed.
+		expect(
+			screen.getByText( 'Trash Post in Block Editor' )
+		).toBeInTheDocument();
 
-    // Test if Trash Post button is displayed.
-    const trashButton = screen.getByRole( 'button', { name: 'Trash Post' } );
-    expect( trashButton ).toBeInTheDocument();
-  } );
+		// Test if Trash Post button is displayed.
+		const trashButton = screen.getByRole( 'button', {
+			name: 'Trash Post',
+		} );
+		expect( trashButton ).toBeInTheDocument();
+		expect( container ).toMatchSnapshot();
+	} );
 
-  it( 'displays modal when Trash Post button is clicked', () => {
-    render( <TrashPostInBlockEditor /> );
+	it( 'displays modal when Trash Post button is clicked', () => {
+		render( <TrashPostInBlockEditor /> );
 
-    // Click Trash Post button to open modal.
-    fireEvent.click( screen.getByRole('button', { name: 'Trash Post' } ) );
+		// Click Trash Post button to open modal.
+		fireEvent.click( screen.getByRole( 'button', { name: 'Trash Post' } ) );
 
-    // Test that modal content is displayed.
-    expect( screen.getByText( 'Are you sure you want to delete this Post?') ).toBeInTheDocument();
-    expect( screen.getByRole( 'button', { name: 'Yes' } ) ).toBeInTheDocument();
-    expect( screen.getByRole( 'button', { name: 'No' } ) ).toBeInTheDocument();
-  } );
+		// Test that modal content is displayed.
+		expect(
+			screen.getByText( 'Are you sure you want to delete this Post?' )
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'button', { name: 'Yes' } )
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'button', { name: 'No' } )
+		).toBeInTheDocument();
+	} );
 
-  it( 'calls trashPost function when Yes button is clicked', () => {
-    render( <TrashPostInBlockEditor /> );
+	it( 'calls trashPost function when Yes button is clicked', () => {
+		render( <TrashPostInBlockEditor /> );
 
-    // Open modal and click Yes button.
-    fireEvent.click( screen.getByRole( 'button', { name: 'Trash Post' } ) );
-    fireEvent.click( screen.getByRole( 'button', { name: 'Yes' } ) );
+		// Open modal and click Yes button.
+		fireEvent.click( screen.getByRole( 'button', { name: 'Trash Post' } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Yes' } ) );
 
-    // Test that trashPost function is called.
-    expect( trashPost ).toHaveBeenCalledTimes( 1 );
-  } );
+		// Test that trashPost function is called.
+		expect( trashPost ).toHaveBeenCalledTimes( 1 );
+	} );
 
-  it( 'closes modal when No button is clicked', () => {
-    render( <TrashPostInBlockEditor /> );
+	it( 'closes modal when No button is clicked', () => {
+		render( <TrashPostInBlockEditor /> );
 
-    // Open modal and click No button.
-    fireEvent.click( screen.getByRole( 'button', { name: 'Trash Post' } ) );
-    fireEvent.click( screen.getByRole( 'button', { name: 'No' } ) );
+		// Open modal and click No button.
+		fireEvent.click( screen.getByRole( 'button', { name: 'Trash Post' } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'No' } ) );
 
-    // Test that modal content is no longer in the document.
-    expect( screen.queryByText( 'Are you sure you want to delete this Post?' ) ).not.toBeInTheDocument();
-  } );
+		// Test that modal content is no longer in the document.
+		expect(
+			screen.queryByText( 'Are you sure you want to delete this Post?' )
+		).not.toBeInTheDocument();
+	} );
 } );

--- a/tests/__snapshots__/Trash.test.tsx.snap
+++ b/tests/__snapshots__/Trash.test.tsx.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TrashPostInBlockEditor renders sidebar and Trash Post button 1`] = `
+<div>
+  <div
+    class="editor-sidebar"
+  >
+    <h2
+      class="interface-complementary-area-header__title"
+    >
+      Trash Post in Block Editor
+    </h2>
+    <div
+      class="components-panel__body is-opened"
+    >
+      <div
+        id="tpbe"
+      >
+        <button
+          class="components-button is-primary"
+          type="button"
+        >
+          Trash Post
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,64 +1,68 @@
-const path = require('path');
-const defaultConfig = require('@wordpress/scripts/config/webpack.config');
+const path = require( 'path' );
+const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
 
 module.exports = {
-  ...defaultConfig,
+	...defaultConfig,
 
-  entry: {
-    app: './src/index.tsx',
-  },
+	entry: {
+		app: './src/index.tsx',
+	},
 
-  output: {
-    path: path.resolve(__dirname, 'dist'),
-    filename: '[name].js',
-  },
+	output: {
+		path: path.resolve( __dirname, 'dist' ),
+		filename: '[name].js',
+	},
 
-  resolve: {
-    extensions: ['.tsx', '.ts', '.js'],
-  },
+	resolve: {
+		extensions: [ '.tsx', '.ts', '.js' ],
+	},
 
-  module: {
-    rules: [
-      {
-        test: /\.ts(x)?$/,
-        exclude: /(node_modules|bower_components)/,
-        use: {
-          loader: 'ts-loader',
-          options: {
-            configFile: 'tsconfig.json',
-            transpileOnly: true
-          }
-        },
-      },
-      {
-        test: /\.js$/,
-        exclude: /(node_modules|bower_components)/,
-        use: {
-          loader: 'babel-loader',
-          options: {
-            presets: ['@babel/preset-env', '@babel/preset-react', '@babel/preset-typescript'],
-          },
-        },
-      },
-      {
-        test: /\.(png|jpg|jpeg|gif|svg)$/,
-        use: [
-          {
-            loader: 'file-loader',
-            options: {
-              name: '[name].[ext]',
-              outputPath: 'images/',
-            },
-          },
-        ],
-      },
-      {
-        test: /\.scss$/,
-        use: ['style-loader', 'css-loader', 'sass-loader'],
-      },
-    ],
-  },
+	module: {
+		rules: [
+			{
+				test: /\.ts(x)?$/,
+				exclude: /(node_modules|bower_components)/,
+				use: {
+					loader: 'ts-loader',
+					options: {
+						configFile: 'tsconfig.json',
+						transpileOnly: true,
+					},
+				},
+			},
+			{
+				test: /\.js$/,
+				exclude: /(node_modules|bower_components)/,
+				use: {
+					loader: 'babel-loader',
+					options: {
+						presets: [
+							'@babel/preset-env',
+							'@babel/preset-react',
+							'@babel/preset-typescript',
+						],
+					},
+				},
+			},
+			{
+				test: /\.(png|jpg|jpeg|gif|svg)$/,
+				use: [
+					{
+						loader: 'file-loader',
+						options: {
+							name: '[name].[ext]',
+							outputPath: 'images/',
+						},
+					},
+				],
+			},
+			{
+				test: /\.scss$/,
+				use: [ 'style-loader', 'css-loader', 'sass-loader' ],
+			},
+		],
+	},
 
-  devtool: 'source-map',
-  mode: 'production'
+	devtool: 'source-map',
+	mode: 'production',
 };


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/trash-post-in-block-editor/issues/2).

## Description / Background Context

Similar to [43](https://github.com/badasswp/search-and-replace/pull/44), there is a need to enforce WP style linting across the codebase to ensure consistency among PRs. Once done, Contributors should be able to lint and perform fixes easily like so:

```js
yarn lint:js:fix
```

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `rm -rf node_modules && yarn build`.
3. Now run `yarn lint:js:fix` to correctly lint your JS files.
4. All other features should work correctly as before.