### PR TITLE
Chore: Use webpack generated dependencies

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -8,7 +8,7 @@
 	"config": {
 		"WP_DEBUG": false,
 		"WP_DEBUG_LOG": false,
-    "WP_DEBUG_DISPLAY": false,
+		"WP_DEBUG_DISPLAY": false,
 		"WP_SITEURL": "http://tpbe.localhost",
 		"WP_HOME": "http://tpbe.localhost"
 	},

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -6,8 +6,9 @@
 	"port": 5437,
 	"testsPort": 5438,
 	"config": {
-		"WP_DEBUG": true,
-		"WP_DEBUG_LOG": true,
+		"WP_DEBUG": false,
+		"WP_DEBUG_LOG": false,
+    "WP_DEBUG_DISPLAY": false,
 		"WP_SITEURL": "http://tpbe.localhost",
 		"WP_HOME": "http://tpbe.localhost"
 	},

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.4
+* Use webpack generated dependencies.
+
 ## 1.0.3
 * Update README docs.
 * Tested up to WP 6.7.2.

--- a/trash-post-in-block-editor.php
+++ b/trash-post-in-block-editor.php
@@ -28,11 +28,11 @@ if ( ! defined( 'WPINC' ) ) {
  * @wp-hook 'enqueue_block_editor_assets'
  */
 add_action( 'enqueue_block_editor_assets', function() {
-	$assets = get_assets( plugin_dir_path( __DIR__ ) . 'dist/app.asset.php' );
+	$assets = get_assets( plugin_dir_path( __FILE__ ) . 'dist/app.asset.php' );
 
 	wp_enqueue_script(
 		'trash-post-in-block-editor',
-		trailingslashit( plugin_dir_url( __FILE__ ) ) . 'dist/app.js',
+		plugin_dir_url( __FILE__ ) . 'dist/app.js',
 		$assets['dependencies'],
 		$assets['version'],
 		false

--- a/trash-post-in-block-editor.php
+++ b/trash-post-in-block-editor.php
@@ -182,6 +182,14 @@ function is_user_permissible( $request ) {
 	return true;
 }
 
+/**
+ * Get Asset dependencies.
+ *
+ * @since 1.0.4
+ *
+ * @param string $path Path to webpack generated PHP asset file.
+ * @return array
+ */
 function get_assets( string $path ): array {
 	$assets = [
 		'version'      => strval( time() ),

--- a/trash-post-in-block-editor.php
+++ b/trash-post-in-block-editor.php
@@ -28,21 +28,13 @@ if ( ! defined( 'WPINC' ) ) {
  * @wp-hook 'enqueue_block_editor_assets'
  */
 add_action( 'enqueue_block_editor_assets', function() {
+	$assets = get_assets( plugin_dir_path( __DIR__ ) . 'dist/app.asset.php' );
+
 	wp_enqueue_script(
 		'trash-post-in-block-editor',
 		trailingslashit( plugin_dir_url( __FILE__ ) ) . 'dist/app.js',
-		[
-			'wp-i18n',
-			'wp-element',
-			'wp-blocks',
-			'wp-components',
-			'wp-editor',
-			'wp-hooks',
-			'wp-compose',
-			'wp-plugins',
-			'wp-edit-post',
-		],
-		'1.0.0',
+		$assets['dependencies'],
+		$assets['version'],
 		false
 	);
 
@@ -188,4 +180,19 @@ function is_user_permissible( $request ) {
 	}
 
 	return true;
+}
+
+function get_assets( string $path ): array {
+	$assets = [
+		'version'      => strval( time() ),
+		'dependencies' => [],
+	];
+
+	if ( ! file_exists( $path ) ) {
+		return $assets;
+	}
+
+	$assets = require_once $path; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable
+
+	return $assets;
 }


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/trash-post-in-block-editor/issues/4).

## Description / Background Context

At the moment, we are currently hard-coding the `enqueue_block_editor_assets` JS dependencies. 

```php
[
	'wp-i18n',
	'wp-element',
	'wp-blocks',
	'wp-components',
	'wp-editor',
	'wp-hooks',
	'wp-compose',
	'wp-plugins',
	'wp-edit-post',
],
```

We should be rather using the `webpack` generated dependencies directly from the PHP file like so:

```php
<?php return array('dependencies' => array('react', 'wp-api-fetch', 'wp-components', 'wp-data', 'wp-editor', 'wp-element', 'wp-i18n', 'wp-plugins'), 'version' => '8ee2789f0d4b0eb6d967');
```

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `rm -rf node_modules && yarn build`.
3. Proceed to block editor to check that plugin works correctly as before without any regressions.