### PR TITLE
Chore: Re-position Trash Icon to Pinned Items Area

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,15 +1,17 @@
-const baseConfig = require( '@wordpress/scripts/config/jest-unit.config.js' );
-
 module.exports = {
-	...baseConfig,
-	preset: 'ts-jest',
+	verbose: true,
+	preset: '@wordpress/jest-preset-default',
 	testEnvironment: 'jsdom',
 	setupFilesAfterEnv: [ './jest.setup.js' ],
+	globals: {
+		window: {},
+	},
 	transform: {
-		'^.+\\.jsx?$': 'babel-jest',
+		'^.+\\.[jt]sx?$': 'babel-jest',
 	},
 	moduleNameMapper: {
 		uuid: require.resolve( 'uuid' ),
-		'\\.(css|scss)$': 'identity-obj-proxy',
+		'\\.(css|less|scss|sass)$': 'identity-obj-proxy',
 	},
+	modulePathIgnorePatterns: [ '/__snapshots__/' ],
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,12 +1,20 @@
 /* eslint-disable no-undef */
 import '@testing-library/jest-dom';
-import '@testing-library/jest-dom/extend-expect.js';
-import '@wordpress/jest-preset-default/scripts/setup-globals';
 
 jest.mock( '@wordpress/components', () => {
 	const original = jest.requireActual( '@wordpress/components' );
 	return {
 		...original,
-		Fill: ( { children } ) => <div>{ children }</div>,
+		Fill: ( { name, children } ) => (
+			<div
+				className={
+					'PinnedItems/core' === name
+						? 'interface-pinned-items'
+						: 'interface-pinned'
+				}
+			>
+				{ children }
+			</div>
+		),
 	};
 } );

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,3 +1,12 @@
+/* eslint-disable no-undef */
 import '@testing-library/jest-dom';
 import '@testing-library/jest-dom/extend-expect.js';
 import '@wordpress/jest-preset-default/scripts/setup-globals';
+
+jest.mock( '@wordpress/components', () => {
+	const original = jest.requireActual( '@wordpress/components' );
+	return {
+		...original,
+		Fill: ( { children } ) => <div>{ children }</div>,
+	};
+} );

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/jest": "^29.5.4",
     "@wordpress/env": "^10.23.0",
     "@wordpress/eslint-plugin": "^22.9.0",
+    "@wordpress/jest-preset-default": "^12.27.0",
     "@wordpress/scripts": "^26.9.0",
     "css-loader": "^6.8.1",
     "file-loader": "^6.2.0",

--- a/src/components/Shortcut.tsx
+++ b/src/components/Shortcut.tsx
@@ -1,0 +1,43 @@
+import { __ } from '@wordpress/i18n';
+import { useDispatch } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
+import { useShortcut } from '@wordpress/keyboard-shortcuts';
+
+import { getShortcut } from '../utils';
+
+/**
+ * Shortcut for Block Editor.
+ *
+ * This method implements the custom shortcut
+ * functionality for this plugin.
+ *
+ * @since 1.0.1
+ *
+ * @param {Object}   props           - The properties object.
+ * @param {Function} props.onKeyDown - The function to call when the shortcut is triggered.
+ *
+ * @return {JSX.Element|null} Shortcut.
+ */
+export const Shortcut = ( { onKeyDown } ): JSX.Element | null => {
+	const dispatch = useDispatch();
+
+	dispatch( 'core/keyboard-shortcuts' ).registerShortcut( {
+		name: 'trash-post-in-block-editor/shortcut',
+		keyCombination: getShortcut(),
+		category: 'global',
+		description: __(
+			'Trash Post in Block Editor',
+			'trash-post-in-block-editor'
+		),
+	} );
+
+	useShortcut(
+		'trash-post-in-block-editor/shortcut',
+		useCallback( () => {
+			onKeyDown();
+			// eslint-disable-next-line react-hooks/exhaustive-deps
+		}, [] )
+	);
+
+	return null;
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,8 @@
 import { __ } from '@wordpress/i18n';
-import { PluginSidebar } from '@wordpress/editor';
+import { trash } from '@wordpress/icons';
+import { useState } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
-import { Fragment, useState } from '@wordpress/element';
-import { Modal, PanelBody, Button } from '@wordpress/components';
+import { Modal, Tooltip, Button, Fill } from '@wordpress/components';
 
 import { trashPost } from './utils';
 
@@ -20,28 +20,22 @@ import './styles/app.scss';
  */
 const TrashPostInBlockEditor = (): JSX.Element => {
 	const [ isModalVisible, setIsModalVisible ] = useState( false );
+	const { wpVersion } = tpbe;
+
+	// Slot fill name changed in WP 6.6.
+	const fillName =
+		parseFloat( wpVersion ) >= 6.6
+			? 'PinnedItems/core'
+			: 'PinnedItems/core/edit-post';
 
 	return (
-		<Fragment>
-			<PluginSidebar
-				name="tpbe-sidebar"
-				title={ __(
-					'Trash Post in Block Editor',
-					'trash-post-in-block-editor'
-				) }
-				icon="trash"
-			>
-				<PanelBody>
-					<div id="tpbe">
-						<Button
-							variant="primary"
-							onClick={ () => setIsModalVisible( true ) }
-						>
-							{ __( 'Trash Post', 'trash-post-in-block-editor' ) }
-						</Button>
-					</div>
-				</PanelBody>
-			</PluginSidebar>
+		<Fill name={ fillName }>
+			<Tooltip text={ __( 'Trash Post', 'trash-post-in-block-editor' ) }>
+				<Button
+					onClick={ () => setIsModalVisible( true ) }
+					icon={ trash }
+				></Button>
+			</Tooltip>
 			{ isModalVisible && (
 				<Modal
 					title={ __( 'Trash Post', 'trash-post-in-block-editor' ) }
@@ -67,11 +61,12 @@ const TrashPostInBlockEditor = (): JSX.Element => {
 					</div>
 				</Modal>
 			) }
-		</Fragment>
+		</Fill>
 	);
 };
 
 registerPlugin( 'trash-post-in-block-editor', {
+	icon: null,
 	render: TrashPostInBlockEditor,
 } );
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import { useState } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
 import { Modal, Tooltip, Button, Fill } from '@wordpress/components';
 
+import { Shortcut } from './components/Shortcut';
 import { trashPost } from './utils';
 
 import './styles/app.scss';
@@ -37,6 +38,7 @@ const TrashPostInBlockEditor = (): JSX.Element => {
 					data-testid="tpbe-trash-btn"
 				></Button>
 			</Tooltip>
+			<Shortcut onKeyDown={ () => setIsModalVisible( true ) } />
 			{ isModalVisible && (
 				<Modal
 					title={ __( 'Trash Post', 'trash-post-in-block-editor' ) }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -32,8 +32,9 @@ const TrashPostInBlockEditor = (): JSX.Element => {
 		<Fill name={ fillName }>
 			<Tooltip text={ __( 'Trash Post', 'trash-post-in-block-editor' ) }>
 				<Button
-					onClick={ () => setIsModalVisible( true ) }
 					icon={ trash }
+					onClick={ () => setIsModalVisible( true ) }
+					data-testid="tpbe-trash-btn"
 				></Button>
 			</Tooltip>
 			{ isModalVisible && (

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,6 +42,7 @@ const TrashPostInBlockEditor = (): JSX.Element => {
 			{ isModalVisible && (
 				<Modal
 					title={ __( 'Trash Post', 'trash-post-in-block-editor' ) }
+					focusOnMount="firstContentElement"
 					onRequestClose={ () => setIsModalVisible( false ) }
 					className="trash-post-modal"
 				>

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -1,6 +1,7 @@
 declare global {
   var tpbe: {
-    url: string;
+		url: string;
+		wpVersion: string;
   };
 }
 

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,4 +1,5 @@
 import apiFetch from '@wordpress/api-fetch';
+import { applyFilters } from '@wordpress/hooks';
 import { select, dispatch } from '@wordpress/data';
 
 /**
@@ -28,4 +29,47 @@ export const trashPost = async () => {
 	} catch ( e ) {
 		createWarningNotice( e );
 	}
+};
+
+/**
+ * Get ShortCut.
+ *
+ * This function filters the user's preferred
+ * shortcut option.
+ *
+ * @since 1.0.5
+ *
+ * @return {Object} Shortcut Option.
+ */
+export const getShortcut = (): { modifier: string; character: string } => {
+	const options = {
+		CMD: {
+			modifier: 'primary',
+			character: 'v',
+		},
+		SHIFT: {
+			modifier: 'primaryShift',
+			character: 'v',
+		},
+		ALT: {
+			modifier: 'primaryAlt',
+			character: 'v',
+		},
+	};
+
+	/**
+	 * Filter Keyboard Shortcut.
+	 *
+	 * By default the passed option would be SHIFT which
+	 * represents `CMD + SHIFT + V`.
+	 *
+	 * @since 1.0.5
+	 *
+	 * @param {Object} Shortcut Option.
+	 * @return {Object}
+	 */
+	return applyFilters(
+		'trash-post-in-block-editor.keyboardShortcut',
+		options.SHIFT
+	) as { modifier: string; character: string };
 };

--- a/tests/Trash.test.tsx
+++ b/tests/Trash.test.tsx
@@ -7,6 +7,14 @@ jest.mock( '../src/utils', () => ( {
 	trashPost: jest.fn(),
 } ) );
 
+jest.mock( '../src/components/Shortcut', () => ( {
+	Shortcut: ( { onKeyDown } ) => {
+		onKeyDown = jest.fn();
+		onKeyDown?.();
+		return null;
+	},
+} ) );
+
 describe( 'TrashPostInBlockEditor', () => {
 	beforeEach( () => {
 		global.tpbe = {

--- a/tests/Trash.test.tsx
+++ b/tests/Trash.test.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import TrashPostInBlockEditor from '../src/index';
@@ -9,75 +8,91 @@ jest.mock( '../src/utils', () => ( {
 	trashPost: jest.fn(),
 } ) );
 
-jest.mock( '@wordpress/editor', () => ( {
-	PluginSidebar: jest.fn( ( { title, children } ) => {
-		return (
-			<div className="editor-sidebar">
-				<h2 className="interface-complementary-area-header__title">
-					{ title }
-				</h2>
-				{ children }
-			</div>
-		);
-	} ),
-} ) );
-
 describe( 'TrashPostInBlockEditor', () => {
-	it( 'renders sidebar and Trash Post button', () => {
+	beforeEach( () => {
+		global.tpbe = {
+			wpVersion: '6.6',
+			url: 'https://example.com/wp-admin/edit.php',
+		};
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'matches snapshot', () => {
 		const { container } = render( <TrashPostInBlockEditor /> );
 
-		// Test if Sidebar title is displayed.
-		expect(
-			screen.getByText( 'Trash Post in Block Editor' )
-		).toBeInTheDocument();
-
-		// Test if Trash Post button is displayed.
-		const trashButton = screen.getByRole( 'button', {
-			name: 'Trash Post',
-		} );
-		expect( trashButton ).toBeInTheDocument();
 		expect( container ).toMatchSnapshot();
 	} );
 
+	it( 'renders sidebar and Trash Post button', () => {
+		const { getByTestId } = render( <TrashPostInBlockEditor /> );
+
+		// Test if Trash Post button is displayed.
+		const trashButton = getByTestId( 'tpbe-trash-btn' );
+		expect( trashButton ).toBeVisible();
+	} );
+
 	it( 'displays modal when Trash Post button is clicked', () => {
-		render( <TrashPostInBlockEditor /> );
+		const { getByTestId, getByText, getByRole } = render(
+			<TrashPostInBlockEditor />
+		);
 
 		// Click Trash Post button to open modal.
-		fireEvent.click( screen.getByRole( 'button', { name: 'Trash Post' } ) );
+		fireEvent.click( getByTestId( 'tpbe-trash-btn' ) );
 
 		// Test that modal content is displayed.
 		expect(
-			screen.getByText( 'Are you sure you want to delete this Post?' )
-		).toBeInTheDocument();
-		expect(
-			screen.getByRole( 'button', { name: 'Yes' } )
-		).toBeInTheDocument();
-		expect(
-			screen.getByRole( 'button', { name: 'No' } )
-		).toBeInTheDocument();
+			getByText( 'Are you sure you want to delete this Post?' )
+		).toBeVisible();
+		expect( getByRole( 'button', { name: 'Yes' } ) ).toBeVisible();
+		expect( getByRole( 'button', { name: 'No' } ) ).toBeVisible();
 	} );
 
-	it( 'calls trashPost function when Yes button is clicked', () => {
-		render( <TrashPostInBlockEditor /> );
+	it( 'calls trashPost function if `Yes` button is clicked', () => {
+		const { getByTestId, getByText, getByRole } = render(
+			<TrashPostInBlockEditor />
+		);
 
-		// Open modal and click Yes button.
-		fireEvent.click( screen.getByRole( 'button', { name: 'Trash Post' } ) );
-		fireEvent.click( screen.getByRole( 'button', { name: 'Yes' } ) );
+		// Click Trash Post button to open modal.
+		fireEvent.click( getByTestId( 'tpbe-trash-btn' ) );
+
+		// Test that modal content is displayed.
+		expect(
+			getByText( 'Are you sure you want to delete this Post?' )
+		).toBeVisible();
+		expect( getByRole( 'button', { name: 'Yes' } ) ).toBeVisible();
+		expect( getByRole( 'button', { name: 'No' } ) ).toBeVisible();
+
+		// click Yes button.
+		fireEvent.click( getByRole( 'button', { name: 'Yes' } ) );
 
 		// Test that trashPost function is called.
 		expect( trashPost ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'closes modal when No button is clicked', () => {
-		render( <TrashPostInBlockEditor /> );
+	it( 'closes modal when if `No` button is clicked', () => {
+		const { getByTestId, getByText, getByRole, queryByText } = render(
+			<TrashPostInBlockEditor />
+		);
 
-		// Open modal and click No button.
-		fireEvent.click( screen.getByRole( 'button', { name: 'Trash Post' } ) );
-		fireEvent.click( screen.getByRole( 'button', { name: 'No' } ) );
+		// Click Trash Post button to open modal.
+		fireEvent.click( getByTestId( 'tpbe-trash-btn' ) );
+
+		// Test that modal content is displayed.
+		expect(
+			getByText( 'Are you sure you want to delete this Post?' )
+		).toBeVisible();
+		expect( getByRole( 'button', { name: 'Yes' } ) ).toBeVisible();
+		expect( getByRole( 'button', { name: 'No' } ) ).toBeVisible();
+
+		// Click No button.
+		fireEvent.click( getByRole( 'button', { name: 'No' } ) );
 
 		// Test that modal content is no longer in the document.
 		expect(
-			screen.queryByText( 'Are you sure you want to delete this Post?' )
+			queryByText( 'Are you sure you want to delete this Post?' )
 		).not.toBeInTheDocument();
 	} );
 } );

--- a/tests/Trash.test.tsx
+++ b/tests/Trash.test.tsx
@@ -1,5 +1,4 @@
 import { render, fireEvent } from '@testing-library/react';
-import '@testing-library/jest-dom';
 
 import TrashPostInBlockEditor from '../src/index';
 import { trashPost } from '../src/utils';

--- a/tests/Trash.test.tsx
+++ b/tests/Trash.test.tsx
@@ -50,7 +50,7 @@ describe( 'TrashPostInBlockEditor', () => {
 		expect( getByRole( 'button', { name: 'No' } ) ).toBeVisible();
 	} );
 
-	it( 'calls trashPost function if `Yes` button is clicked', () => {
+	it( 'calls trashPost function if the `Yes` button is clicked', () => {
 		const { getByTestId, getByText, getByRole } = render(
 			<TrashPostInBlockEditor />
 		);
@@ -72,7 +72,7 @@ describe( 'TrashPostInBlockEditor', () => {
 		expect( trashPost ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'closes modal when if `No` button is clicked', () => {
+	it( 'closes modal if the `No` button is clicked', () => {
 		const { getByTestId, getByText, getByRole, queryByText } = render(
 			<TrashPostInBlockEditor />
 		);

--- a/tests/Trash.test.tsx
+++ b/tests/Trash.test.tsx
@@ -26,7 +26,7 @@ describe( 'TrashPostInBlockEditor', () => {
 		expect( container ).toMatchSnapshot();
 	} );
 
-	it( 'renders sidebar and Trash Post button', () => {
+	it( 'renders trash button in pinned item area', () => {
 		const { getByTestId } = render( <TrashPostInBlockEditor /> );
 
 		// Test if Trash Post button is displayed.
@@ -34,7 +34,7 @@ describe( 'TrashPostInBlockEditor', () => {
 		expect( trashButton ).toBeVisible();
 	} );
 
-	it( 'displays modal when Trash Post button is clicked', () => {
+	it( 'displays modal when trash button is clicked', () => {
 		const { getByTestId, getByText, getByRole } = render(
 			<TrashPostInBlockEditor />
 		);

--- a/tests/__snapshots__/Trash.test.tsx.snap
+++ b/tests/__snapshots__/Trash.test.tsx.snap
@@ -2,7 +2,9 @@
 
 exports[`TrashPostInBlockEditor matches snapshot 1`] = `
 <div>
-  <div>
+  <div
+    class="interface-pinned-items"
+  >
     <button
       class="components-button has-icon"
       data-testid="tpbe-trash-btn"

--- a/tests/__snapshots__/Trash.test.tsx.snap
+++ b/tests/__snapshots__/Trash.test.tsx.snap
@@ -1,29 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TrashPostInBlockEditor renders sidebar and Trash Post button 1`] = `
+exports[`TrashPostInBlockEditor matches snapshot 1`] = `
 <div>
-  <div
-    class="editor-sidebar"
-  >
-    <h2
-      class="interface-complementary-area-header__title"
+  <div>
+    <button
+      class="components-button has-icon"
+      data-testid="tpbe-trash-btn"
+      type="button"
     >
-      Trash Post in Block Editor
-    </h2>
-    <div
-      class="components-panel__body is-opened"
-    >
-      <div
-        id="tpbe"
+      <svg
+        aria-hidden="true"
+        focusable="false"
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <button
-          class="components-button is-primary"
-          type="button"
-        >
-          Trash Post
-        </button>
-      </div>
-    </div>
+        <path
+          clip-rule="evenodd"
+          d="M12 5.5A2.25 2.25 0 0 0 9.878 7h4.244A2.251 2.251 0 0 0 12 5.5ZM12 4a3.751 3.751 0 0 0-3.675 3H5v1.5h1.27l.818 8.997a2.75 2.75 0 0 0 2.739 2.501h4.347a2.75 2.75 0 0 0 2.738-2.5L17.73 8.5H19V7h-3.325A3.751 3.751 0 0 0 12 4Zm4.224 4.5H7.776l.806 8.861a1.25 1.25 0 0 0 1.245 1.137h4.347a1.25 1.25 0 0 0 1.245-1.137l.805-8.861Z"
+          fill-rule="evenodd"
+        />
+      </svg>
+    </button>
   </div>
 </div>
 `;

--- a/trash-post-in-block-editor.php
+++ b/trash-post-in-block-editor.php
@@ -29,6 +29,7 @@ if ( ! defined( 'WPINC' ) ) {
  */
 add_action( 'enqueue_block_editor_assets', function() {
 	$assets = get_assets( plugin_dir_path( __FILE__ ) . 'dist/app.asset.php' );
+	global $wp_version;
 
 	wp_enqueue_script(
 		'trash-post-in-block-editor',
@@ -48,7 +49,8 @@ add_action( 'enqueue_block_editor_assets', function() {
 		'trash-post-in-block-editor',
 		'tpbe',
 		[
-			'url' => add_query_arg(
+			'wpVersion' => $wp_version,
+			'url'       => add_query_arg(
 				[
 					'post_type' => get_post_type()
 				],


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/trash-post-in-block-editor/issues/10).

## Description / Background Context

At the moment, users are forced to go into the Plugin sidebar just to use the trash button. We should implement a fix for this such that users only have to click on the icon on the Pinned items area to delete a post.

<img width="432" height="88" alt="Image" src="https://github.com/user-attachments/assets/5d3d8520-c5ad-4fbf-b7c3-2d3532a51f23" />

This PR resolves this issue.

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `rm -rf node_modules && yarn build`.
3. Click on the Trash icon.
4. Observe that modal is shown to user.
5. Click on `Yes`.
6. Observe that Post is deleted and user is directed to the posts dashboard page.
7. Finally, for another article, click on the CMD + SHIFT + V button on your keyboard.
8. Observe that modal is called again.