### PR TITLE
Chore: Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+This PR resolves #1. <!-- What issue does this PR resolve? -->
+
+## Description / Background Context
+
+<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
+
+## Testing Instructions
+
+<!-- Please include step by step instructions on how to test this PR. -->
+<!-- 1. Pull PR to local. -->
+<!-- 2. Run `yarn build` to build correctly. -->
+<!-- 3. etc. -->
+
+## Screenshots / Screencast
+
+<!-- If you would like to upload screenshots, feel free to show the difference between before and after the change. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.0
+* Chore: Added a pull request template file.
+
 ## 1.1.1
 * Use Composer for plugin setup.
 * Tested up to WP 6.9.

--- a/readme.txt
+++ b/readme.txt
@@ -42,6 +42,9 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 
 == Changelog ==
 
+= 1.2.0
+* Chore: Added a pull request template file.
+
 = 1.1.1 =
 * Use Composer for plugin setup.
 * Tested up to WP 6.9.


### PR DESCRIPTION
This PR resolves [WP-56](https://appworld.atlassian.net/browse/WP-56).

## Description / Background Context

This PR simply introduces a template that enables all contributors use the same template for raising PRs.

## Testing Instructions

- Pull PR to local.
- Observe that `pull_request_template.md` is now part of the `.github` folder.
- Check out to a new branch from this branch.
- Attempt to raise a new PR.
- Observe that you can now see the template in action.