### PR TITLE
Release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.1
+* Hotfix: Resolve issue with `validate_callback` method: `is_numeric`.
+
 ## 1.2.0
 * Feat: Added language translations for the following `Japanese` ,`Indonesian`, `Turkish`, `Polish`, `Dutch`, `Brazil` and `Portuguese`.
 * Chore: Modify Shortcut command - CMD + Shift + Delete (backspace).

--- a/inc/Routes/Trash.php
+++ b/inc/Routes/Trash.php
@@ -31,7 +31,7 @@ class Trash extends Route implements Router {
 			[
 				'args'                => [
 					'id' => [
-						'validate_callback' => 'is_numeric',
+						'validate_callback' => [ $this, 'validate_numeric' ],
 						'sanitize_callback' => 'absint',
 					],
 				],
@@ -80,5 +80,18 @@ class Trash extends Route implements Router {
 				'ID' => $post_id,
 			]
 		);
+	}
+
+	/**
+	 * Validate numeric REST parameter.
+	 *
+	 * @param mixed            $value   Value to validate.
+	 * @param \WP_REST_Request $request Full REST request object.
+	 * @param string           $param   Parameter name.
+	 *
+	 * @return bool Whether the value is valid.
+	 */
+	public function validate_numeric( $value, $request, $param ) {
+		return is_numeric( $value );
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "trash-post-in-block-editor",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"description": "Delete a Post from within the WP Block Editor.",
 	"author": "badasswp",
 	"license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -42,6 +42,9 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 
 == Changelog ==
 
+= 1.2.1 =
+* Hotfix: Resolve issue with `validate_callback` method: `is_numeric`.
+
 = 1.2.0 =
 * Feat: Added language translations for the following `Japanese` ,`Indonesian`, `Turkish`, `Polish`, `Dutch`, `Brazil` and `Portuguese`.
 * Chore: Modify Shortcut command - CMD + Shift + Delete (backspace).

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: badasswp, activist507
 Tags: delete, trash, post, block, editor.
 Requires at least: 6.6
 Tested up to: 6.9
-Stable tag: 1.2.0
+Stable tag: 1.2.1
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/tests/unit/php/Routes/TrashTest.php
+++ b/tests/unit/php/Routes/TrashTest.php
@@ -14,6 +14,7 @@ use TrashPostInBlockEditor\Routes\Trash;
 /**
  * @covers TrashPostInBlockEditor\Routes\Trash::register_route
  * @covers TrashPostInBlockEditor\Routes\Trash::get_rest_response
+ * @covers TrashPostInBlockEditor\Routes\Trash::validate_numeric
  */
 class TrashTest extends TestCase {
 	public Trash $trash;

--- a/tests/unit/php/Routes/TrashTest.php
+++ b/tests/unit/php/Routes/TrashTest.php
@@ -36,7 +36,7 @@ class TrashTest extends TestCase {
 				[
 					'args'                => [
 						'id' => [
-							'validate_callback' => 'is_numeric',
+							'validate_callback' => [ $this->trash, 'validate_numeric' ],
 							'sanitize_callback' => 'absint',
 						],
 					],
@@ -104,6 +104,16 @@ class TrashTest extends TestCase {
 		$response = $this->trash->get_rest_response( $request );
 
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertConditionsMet();
+	}
+
+	public function test_validate_numeric() {
+		$request = Mockery::mock( WP_REST_Request::class )->makePartial();
+		$request->shouldAllowMockingProtectedMethods();
+
+		$response = $this->trash->validate_numeric( 1, $request, 'id' );
+
+		$this->assertTrue( $response );
 		$this->assertConditionsMet();
 	}
 }

--- a/tests/unit/php/Services/RoutesTest.php
+++ b/tests/unit/php/Services/RoutesTest.php
@@ -59,7 +59,7 @@ class RoutesTest extends TestCase {
 				[
 					'args'                => [
 						'id' => [
-							'validate_callback' => 'is_numeric',
+							'validate_callback' => [ $trash, 'validate_numeric' ],
 							'sanitize_callback' => 'absint',
 						],
 					],

--- a/trash-post-in-block-editor.php
+++ b/trash-post-in-block-editor.php
@@ -3,7 +3,7 @@
  * Plugin Name: Trash Post in Block Editor
  * Plugin URI:  https://github.com/badasswp/trash-post-in-block-editor
  * Description: Delete a Post from within the WP Block Editor.
- * Version:     1.2.0
+ * Version:     1.2.1
  * Author:      badasswp
  * Author URI:  https://github.com/badasswp
  * License:     GPL v2 or later


### PR DESCRIPTION
This PR resolves a Hotfix issue in PROD.

## Description / Background Context

We recently encountered an issue in production where the `is_numeric` validate callback is being flagged. This PR resolves this issue correctly.

## Testing Instructions

- Pull PR to local.
- Build correctly using `yarn build`.
- Run `composer run test`.
- Observe that all unit tests are passing correctly.
- Observe that the post is deleted correctly when the trash icon is clicked.

## Screenshots / Screencast

<img width="1435" height="897" alt="Screenshot 2026-04-30 at 14 39 39" src="https://github.com/user-attachments/assets/28a63909-4779-4218-bf0f-b6eb58f3a71d" />
